### PR TITLE
禁用 reqwest 的默认依赖。修改 tokio 使用的 features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 /target
 /Cargo.lock

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@ serde = {version="1" ,features=["derive"]}
 serde_urlencoded = "0.6.1"
 serde_json="1"
 tokio = {version="1",features=["full"]}
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 actix = "0.12"
 log="0"
 env_logger = "0.7"

--- a/nacos-tonic-discover/Cargo.toml
+++ b/nacos-tonic-discover/Cargo.toml
@@ -6,18 +6,18 @@ license = "MIT/Apache-2.0"
 description = "nacos tonic discover "
 repository = "https://github.com/heqingpan/nacos_rust_client"
 readme = "README.md"
-keywords = ["nacos", "tonic","discover"]
+keywords = ["nacos", "tonic", "discover"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nacos_rust_client = {version="0.2", path="../nacos_rust_client" }
+nacos_rust_client = { version = "0.2", path = "../nacos_rust_client" }
 tonic = "0.7"
 tower = "0.4"
 actix = "0.12"
-log="0"
-tokio = {version="1",features=["full"]}
-anyhow="1"
+log = "0"
+tokio = { version = "1", features = ["sync"] }
+anyhow = "1"
 lazy_static = "1.4"
 

--- a/nacos_rust_client/Cargo.toml
+++ b/nacos_rust_client/Cargo.toml
@@ -12,18 +12,17 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow="1"
-serde = {version="1" ,features=["derive"]}
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
 serde_urlencoded = "0.6.1"
-serde_json="1"
-tokio = {version="1",features=["full"]}
-reqwest = { version = "0.11", features = ["json"] }
-rust-crypto="0.2.36"
+serde_json = "1"
+tokio = { version = "1", features = ["net", "sync", "signal"] }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
+rust-crypto = "0.2.36"
 actix = "0.12"
-log="0"
-env_logger = "0.7"
+log = "0"
 local_ipaddress = "0.1.3"
-inner-mem-cache="0.1.3"
-rand="0.8"
+inner-mem-cache = "0.1.3"
+rand = "0.8"
 flate2 = "1.0"
 lazy_static = "1.4"


### PR DESCRIPTION
禁用 reqwest 的默认依赖: 项目中并未使用到https请求, 禁用默认依赖可以移除对openssl的依赖, 方便静态编译.
修改 tokio 使用的 features: 将除examples外的tokio的features修改为项目中有使用到的

另外编译时有大量的警告, 有打算处理吗?