### PR TITLE
替换过时的依赖项 rust-crypto

### DIFF
--- a/nacos_rust_client/Cargo.toml
+++ b/nacos_rust_client/Cargo.toml
@@ -13,12 +13,11 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-serde = { version = "1", features = ["derive","rc"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_urlencoded = "0.6.1"
 serde_json = "1"
 tokio = { version = "1", features = ["net", "sync", "signal"] }
 reqwest = { version = "0.11", features = ["json"], default-features = false }
-rust-crypto = "0.2.36"
 actix = "0.12"
 log = "0"
 local_ipaddress = "0.1.3"
@@ -28,6 +27,8 @@ flate2 = "1.0"
 lazy_static = "1.4"
 tonic = "0.9"
 prost = "0.11"
-async-stream="0.3.2"
+async-stream = "0.3.2"
 futures-core = "0.3.7"
 tokio-stream = "0.1"
+md-5 = "0.10.0"
+hex = "0.4"

--- a/nacos_rust_client/src/client/mod.rs
+++ b/nacos_rust_client/src/client/mod.rs
@@ -10,7 +10,7 @@ pub mod utils;
 
 pub mod auth;
 
-use crypto::digest::Digest;
+use md5::{Md5, Digest};
 use serde::{Deserialize, Serialize};
 
 pub use self::builder::ClientBuilder;
@@ -34,9 +34,10 @@ pub fn now_millis() -> u64 {
 }
 
 pub fn get_md5(content: &str) -> String {
-    let mut m = crypto::md5::Md5::new();
-    m.input_str(content);
-    m.result_str()
+    let mut m = Md5::new();
+    m.update(content.as_bytes());
+
+    hex::encode(&m.finalize()[..])
 }
 
 impl HostInfo {

--- a/nacos_rust_client/src/client/mod.rs
+++ b/nacos_rust_client/src/client/mod.rs
@@ -220,3 +220,13 @@ pub enum ProtocolMode {
     Http,
     Grpc,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_md5() {
+        assert_eq!(get_md5("hello"), String::from("5d41402abc4b2a76b9719d911017c592"));
+    }
+}


### PR DESCRIPTION
rust-crypto 已经很久没有更新了，它依赖了 rustc-serialize，在新版本的rust编译时会产生warning，类似于
```
warning: the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
```

所以使用 https://github.com/RustCrypto/hashes 替换了 rust-crypto