### PR TITLE
Fixed a bug that caused the service discovery function to not work pr…

### DIFF
--- a/nacos_rust_client/src/client/naming_client/api_model.rs
+++ b/nacos_rust_client/src/client/naming_client/api_model.rs
@@ -86,9 +86,9 @@ impl InstanceVO {
 
     pub fn to_instance(self) -> Instance {
         let mut instance = Instance::default();
-        if let Some(service) = &self.service {
+        if let Some(service_name) = &self.service_name {
             if let Some((group_name, service_name)) =
-                NamingUtils::split_group_and_serivce_name(service)
+                NamingUtils::split_group_and_serivce_name(service_name)
             {
                 instance.group_name = group_name;
                 instance.service_name = service_name;


### PR DESCRIPTION
Fixed a bug that caused the service discovery function to not work properly. The reason was that an incorrect parameter was passed into a function, and the service_name was passed as the service field, causing the problem. After the fix, the service discovery function can be used normally.